### PR TITLE
downgrade release artifact to fix autoupdater

### DIFF
--- a/.github/workflows/release-clang.yml
+++ b/.github/workflows/release-clang.yml
@@ -70,7 +70,7 @@ jobs:
         mv moonjit/src/libluajit.so stage/libluajit.so
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: Build (clang)
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         mv moonjit/src/libluajit.so stage/libluajit.so
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: Build
         path: |


### PR DESCRIPTION
downgrade release artifact workflow to fix a github api bug relating to getting artifact urls